### PR TITLE
update body_set to use Readline.readline so that it is consistent with cli.rb, and stdin input work well

### DIFF
--- a/lib/htty/cli/commands/body_set.rb
+++ b/lib/htty/cli/commands/body_set.rb
@@ -1,3 +1,4 @@
+require 'readline'
 require File.expand_path("#{File.dirname __FILE__}/../command")
 require File.expand_path("#{File.dirname __FILE__}/../display")
 require File.expand_path("#{File.dirname __FILE__}/body_request")
@@ -45,7 +46,7 @@ class HTTY::CLI::Commands::BodySet < HTTY::CLI::Command
       lines            = []
       empty_line_count = 0
       while empty_line_count < 2 do
-        if (input = $stdin.gets).nil?
+        if (input = Readline.readline).nil?
           break
         end
         lines << input.chomp


### PR DESCRIPTION
Scripting with stdin and body_set did not work with the current version.  

Root cause seems to be a mix of Readline and stdin being used.

Updating the body_set.rb to use Readline resolved the issue.

It would be awesome if you would pull this change in.
