### PR TITLE
Use appropriate ruby debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,13 @@ source 'http://rubygems.org'
 
 gem 'rake'
 
+ruby_version = RUBY_VERSION.split('.')
+is_1_9 = ruby_version[0] == '1' and ruby_version[1] == '9'
+
 group :development do
   gem 'autotest'
   gem 'autotest-fsevent'
-  gem 'ruby-debug'
+  gem is_1_9 ? 'ruby-debug19' : 'ruby-debug'
 end
 
 group :doc do


### PR DESCRIPTION
Bundler uses appropriate version of ruby-debug gem depending on whether you are developing in 1.8.x or 1.9.x
