### PR TITLE
Selective query unset

### DIFF
--- a/lib/htty/cli/commands/query_unset.rb
+++ b/lib/htty/cli/commands/query_unset.rb
@@ -26,7 +26,7 @@ class HTTY::CLI::Commands::QueryUnset < HTTY::CLI::Command
   # Returns the arguments for the command-line usage of the _query-unset_
   # command.
   def self.command_line_arguments
-    'NAME'
+    'NAME [VALUE]'
   end
 
   # Returns the help text for the _query-unset_ command.
@@ -63,7 +63,8 @@ class HTTY::CLI::Commands::QueryUnset < HTTY::CLI::Command
   def perform
     add_request_if_has_response do |request|
       self.class.notify_if_cookies_cleared request do
-        request.query_unset(*escape_or_warn_of_escape_sequences(arguments))
+        unset_method = arguments.length == 2 ? :query_remove : :query_unset
+        request.send(unset_method, *escape_or_warn_of_escape_sequences(arguments))
       end
     end
   end

--- a/spec/unit/htty/cli/commands/query_unset_spec.rb
+++ b/spec/unit/htty/cli/commands/query_unset_spec.rb
@@ -1,0 +1,37 @@
+require 'rspec'
+require File.expand_path("#{File.dirname __FILE__}/../../../../../lib/htty/cli/commands/query_remove")
+require File.expand_path("#{File.dirname __FILE__}/../../../../../lib/htty/session")
+
+describe HTTY::CLI::Commands::QueryUnset do
+  before :each do
+    @session = HTTY::Session.new('')
+  end
+
+  describe 'with existing query string with duplicate keys set' do
+    before :each do
+      @session.requests.last.uri.query = 'test=true&test=false'
+    end
+
+    describe 'with only key specified' do
+      it 'should remove all entries' do
+        query_unset = create_query_unset_and_perform('test')
+        query_unset.session.requests.last.uri.query.should == ''
+      end
+    end
+
+    describe 'with key and value specified' do
+      it 'should remove matching entry only' do
+        query_unset = create_query_unset_and_perform('test', 'true')
+        query_unset.session.requests.last.uri.query.should == 'test=false'
+      end
+    end
+  end
+
+  def create_query_unset_and_perform(*arguments)
+    query_unset = HTTY::CLI::Commands::QueryUnset.new(:session => @session,
+                                                      :arguments => arguments)
+    query_unset.perform
+    query_unset
+  end
+
+end


### PR DESCRIPTION
New usage, assuming existing query string of `?foo=bar&foo=bak&kale=green`:

`query-unset foo` -> `?kale=green`

`query-unset foo bak` -> `?foo=bar&kale=green`
