### PR TITLE
Fix line wrapping by adding non-printable text delimiters to format codes

### DIFF
--- a/lib/htty/cli/display.rb
+++ b/lib/htty/cli/display.rb
@@ -39,10 +39,10 @@ module HTTY::CLI::Display
 
   def format(string, *attributes)
     segments = attributes.collect do |a|
-      "\x1b[#{FORMATS[a]}m"
+      "\001\x1b[#{FORMATS[a]}m\002"
     end
     segments << string
-    segments << "\x1b[0m"
+    segments << "\001\x1b[0m\002"
     segments.join ''
   end
 


### PR DESCRIPTION
When you get to the end of the line like this:

```
http://0.0.0.0/> aaaaaaaaaaaaaaaaaaaaaaaaaa
```

htty doesn't jump new line and instead overwrites characters onto the same line, like this:

```
aaaa://0.0.0.0/> aaaaaaaaaaaaaaaaaaaaaaaaaa
```

This seems to be the problem described in issue #87 (https://github.com/htty/htty/issues/87) and is probably related to issue #55 (https://github.com/htty/htty/issues/55). 

It happens because htty's formatting codes aren't contained within the delimiters (\001 and \002) that readline uses to indicate non-visible characters (http://superuser.com/a/301355/35533). It sounds like this breaks line wrapping by interfering with the CLI's character counting, which is used to determine when to move the cursor to a new line (http://stackoverflow.com/questions/8806643/colorized-output-breaks-linewrapping-with-readline#comment11105860_8883506). 

Regardless of the exact mechanism, adding the delimiters led to proper line wrapping on my setup (Gnome Terminal).
