### PR TITLE
Safely encode reserved parameters in query string

### DIFF
--- a/lib/htty/cli/url_escaping.rb
+++ b/lib/htty/cli/url_escaping.rb
@@ -17,7 +17,13 @@ module HTTY::CLI::UrlEscaping
             'sequences'
         a
       else
-        URI.escape a
+        # There's a lot of confusion about this, the default implementation
+        # of URI.escape is marked as "obsolete", CGI.escape does another work,
+        # a safe solution seems to use https://github.com/sporkmonger/addressable
+        # without adding a new dependecy I found that encode all not unreserved
+        # characters (unfortunately that doesn't mean all reserved characters) it's
+        # a pretty safe solution, see http://tools.ietf.org/html/rfc3986#section-2.3
+        URI.escape(a, /[^-_.~a-zA-Z0-9]/)
       end
     end
   end

--- a/spec/integration/htty/cli/commands/query_set_spec.rb
+++ b/spec/integration/htty/cli/commands/query_set_spec.rb
@@ -63,10 +63,10 @@ describe HTTY::CLI::Commands::QuerySet do
     end
 
     it 'should play nice with nested fields' do
-      session.requests.last.uri.query = 'test[my][]=1'
+      instance('test[my][]', '1').perform
       instance('test[my][]', '2').perform
       instance('test', '3').perform
-      session.requests.last.uri.query.should == 'test[my][]=2&test=3'
+      session.requests.last.uri.query.should == 'test%5Bmy%5D%5B%5D=2&test=3'
     end
   end
 end

--- a/spec/unit/htty/url_escaping.rb
+++ b/spec/unit/htty/url_escaping.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require File.expand_path("#{File.dirname __FILE__}/../../../lib/htty/cli/url_escaping")
+
+describe HTTY::CLI::UrlEscaping do
+  subject do
+    o = Object.new.extend(HTTY::CLI::UrlEscaping)
+    o.stub(:say)
+    o
+  end
+
+  describe '.escape_or_warn_of_escape_sequences' do
+    context 'when argument is already escaped' do
+      let(:escaped_string) {'Hello%20World'}
+
+      it 'should not escape it twice' do
+        should_not_escape(escaped_string)
+      end
+
+      it 'should warn the user' do
+        subject.should_receive(:say).once
+        escape(escaped_string)
+      end
+    end
+
+    context 'when argument contains reserved characters' do
+      let(:unescaped_string) {'Hello World'}
+
+      it 'should escape it' do
+        should_escape(unescaped_string)
+      end
+
+      it 'should not warn the user' do
+        subject.should_receive(:say).never
+        escape(unescaped_string)
+      end
+    end
+
+    context 'when argument contains not reserved characters' do
+      let(:unescaped_string) {'HelloWorld'}
+
+      it 'should not escape it' do
+        should_not_escape(unescaped_string)
+      end
+
+      it 'should not warn the user' do
+        subject.should_receive(:say).never
+        escape(unescaped_string)
+      end
+    end
+
+    # http://tools.ietf.org/html/rfc3986#section-2.2
+    ":/?#[]@!$&'()*+,;=".each_char do |reserved_character|
+      it "should escape reserved character '#{reserved_character}'" do
+        should_escape(reserved_character)
+      end
+    end
+  end
+
+  def should_escape(s)
+    escape(s).should_not == [s]
+  end
+
+  def should_not_escape(s)
+    escape(s).should == [s]
+  end
+
+  def escape(s)
+    subject.escape_or_warn_of_escape_sequences([s])
+  end
+end


### PR DESCRIPTION
Fixes #76

There's a lot of confusion about this, the default implementation of
URI.escape is marked as "obsolete", CGI.escape does another work, a safe
solution seems to use https://github.com/sporkmonger/addressable without
adding a new dependecy I found that encode all not unreserved characters
(unfortunately that doesn't mean all reserved characters) it's a pretty
safe solution, see http://tools.ietf.org/html/rfc3986#section-2.3
