### PR TITLE
query-add and query-set arguments validation

### DIFF
--- a/lib/htty/cli/commands/query_add.rb
+++ b/lib/htty/cli/commands/query_add.rb
@@ -60,6 +60,9 @@ class HTTY::CLI::Commands::QueryAdd < HTTY::CLI::Command
 
   # Performs the _query-add_ command.
   def perform
+    if arguments.empty?
+      raise ArgumentError, 'wrong number of arguments (0 for N)'
+    end
     add_request_if_new do |request|
       self.class.notify_if_cookies_cleared request do
         escaped_arguments = escape_or_warn_of_escape_sequences(arguments)

--- a/lib/htty/cli/commands/query_set.rb
+++ b/lib/htty/cli/commands/query_set.rb
@@ -60,6 +60,9 @@ class HTTY::CLI::Commands::QuerySet < HTTY::CLI::Command
 
   # Performs the _query-set_ command.
   def perform
+    if arguments.empty?
+      raise ArgumentError, 'wrong number of arguments (0 for N)'
+    end
     add_request_if_new do |request|
       self.class.notify_if_cookies_cleared request do
         escaped_arguments = escape_or_warn_of_escape_sequences(arguments)

--- a/spec/integration/htty/cli/commands/query_add_spec.rb
+++ b/spec/integration/htty/cli/commands/query_add_spec.rb
@@ -15,6 +15,12 @@ describe HTTY::CLI::Commands::QueryAdd do
     klass.new :session => session, :arguments => arguments
   end
 
+  describe 'without an argument' do
+    it 'should raise an error' do
+      expect{instance.perform}.to raise_error(ArgumentError)
+    end
+  end
+
   describe 'with key argument only' do
     describe 'without key already present' do
       it 'should add key' do

--- a/spec/integration/htty/cli/commands/query_set_spec.rb
+++ b/spec/integration/htty/cli/commands/query_set_spec.rb
@@ -15,6 +15,12 @@ describe HTTY::CLI::Commands::QuerySet do
     klass.new :session => session, :arguments => arguments
   end
 
+  describe 'without an argument' do
+    it 'should raise an error' do
+      expect{instance.perform}.to raise_error(ArgumentError)
+    end
+  end
+
   describe 'with one argument' do
     it 'should assign a single key' do
       instance('test').perform


### PR DESCRIPTION
Fixes #71

Sometimes arguments validation is done explicitly, sometimes it's an ArgumentError raised by a method call, moreover there's a duplication between the command description and the implicit/explicit validation, we need a better way, a pull request is coming in the near future :smile: 
