### PR TITLE
Remove query string from uri when empty

### DIFF
--- a/lib/htty/request.rb
+++ b/lib/htty/request.rb
@@ -494,8 +494,10 @@ protected
     components = URI::HTTP::COMPONENT.inject({}) do |result, c|
       result.merge c => uri.send(c)
     end
+    components = components.merge(changed_components)
+    components[:query] = nil if components[:query] && components[:query].empty?
     self.class.send(:set_up_cookies_and_authentication, self) do
-      @uri = self.class.build_uri(components.merge(changed_components))
+      @uri = self.class.build_uri(components)
     end
   end
 

--- a/spec/integration/htty/cli/commands/query_remove_spec.rb
+++ b/spec/integration/htty/cli/commands/query_remove_spec.rb
@@ -15,6 +15,24 @@ describe HTTY::CLI::Commands::QueryRemove do
     klass.new :session => session, :arguments => arguments
   end
 
+  describe 'with existing query string with only one key and value' do
+    before :each do
+      session.requests.last.uri.query = 'test=true'
+    end
+
+    describe 'with only key in query string' do
+      it 'should empty the query string' do
+        instance('test').perform
+        session.requests.last.uri.query.should be_nil
+      end
+
+      it 'should not leave a trailing question mark' do
+        instance('test').perform
+        session.requests.last.uri.to_s.should_not end_with('?')
+      end
+    end
+  end
+
   describe 'with existing query string with duplicate keys set' do
     before :each do
       session.requests.last.uri.query = 'test=true&test=false'

--- a/spec/integration/htty/cli/commands/query_unset_spec.rb
+++ b/spec/integration/htty/cli/commands/query_unset_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require File.expand_path("#{File.dirname __FILE__}/../../../../../lib/htty/session")
 require File.expand_path("#{File.dirname __FILE__}/../../../../../lib/htty/cli/commands/address")
 require File.expand_path("#{File.dirname __FILE__}/../../../../../lib/htty/cli/commands/query_unset")
 
@@ -23,7 +24,12 @@ describe HTTY::CLI::Commands::QueryUnset do
     describe 'with only key specified' do
       it 'should remove all entries' do
         instance('test').perform
-        session.requests.last.uri.query.should == ''
+        session.requests.last.uri.query.should be_nil
+      end
+
+      it 'should not leave a trailing question mark' do
+        instance('test').perform
+        session.requests.last.uri.to_s.should_not end_with('?')
       end
     end
 


### PR DESCRIPTION
Fixes #64

When `URI.query` is an empty string `URI.to_s` will leave a trailing
question mark, the true "emptiness" for query string is obtained with
`nil`
