### PR TITLE
Don't add nil as last request

### DIFF
--- a/lib/htty/cli/command.rb
+++ b/lib/htty/cli/command.rb
@@ -203,11 +203,11 @@ protected
   # Yields the last request in #session. If the block returns a different
   # request, it is added to the requests of #session.
   def add_request_if_new
-    requests     = session.requests
-    last_request = requests.last
-    unless (new_request = yield(last_request)).equal?(last_request)
-      requests << new_request
-    end
+    last_request = session.requests.last
+    maybe_next_request = yield(last_request)
+    session.requests << maybe_next_request unless (
+      maybe_next_request.nil? or maybe_next_request.equal?(last_request)
+    )
     self
   end
 

--- a/spec/unit/htty/command.rb
+++ b/spec/unit/htty/command.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require File.expand_path("#{File.dirname __FILE__}/../../../lib/htty/request")
+require File.expand_path("#{File.dirname __FILE__}/../../../lib/htty/cli/command")
+
+describe HTTY::CLI::Command do
+  let(:last_request) {HTTY::Request.new('http://0.0.0.0')}
+  let(:requests) {[last_request]}
+  let(:session) do
+    session = double
+    session.stub(:requests) {requests}
+    session
+  end
+
+  subject{described_class.new(:session => session)}
+
+  describe '#add_request_if_new' do
+    context 'when command returns nil' do
+      it 'should not add the request' do
+        expect do
+          subject.send(:add_request_if_new) do
+            nil
+          end
+        end.to_not change{subject.session.requests.count}
+      end
+    end
+
+    context 'when command returns the same request' do
+      it 'should not add the request' do
+        expect do
+          subject.send(:add_request_if_new) do
+            last_request
+          end
+        end.to_not change{subject.session.requests.count}
+      end
+    end
+
+    context 'when command returns a different request' do
+      it 'should add the request' do
+        expect do
+          subject.send(:add_request_if_new) do
+            HTTY::Request.new('http://0.0.0.0/foo')
+          end
+        end.to change{subject.session.requests.count}.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #102

A command could yield a valid request but also nil so we need to check
that otherwise nil will be added as next request blowing up everything

I fixed this right aways because I think it's a pretty serious :bug:
