### PR TITLE
Issue 99

### DIFF
--- a/lib/htty/request.rb
+++ b/lib/htty/request.rb
@@ -272,24 +272,7 @@ public
   # HTTY::NoLocationHeaderError.
   def follow(response)
     raise HTTY::NoResponseError unless response
-
-    _, location_header = response.headers.detect do |name, value|
-      name == HTTY::Response::LOCATION_HEADER_NAME
-    end
-
-    raise HTTY::NoLocationHeaderError unless location_header
-
-    location_uri = URI.parse(location_header)
-    if location_uri.absolute?
-      address location_header
-    else
-      location_uri.scheme = @uri.scheme
-      location_uri.userinfo = @uri.userinfo
-      location_uri.host = @uri.host
-      location_uri.port = @uri.port
-      location_uri.path = (Pathname.new(@uri.path) + location_uri.path).to_s
-      address location_uri.to_s
-    end
+    response.follow_relative_to(self)
   end
 
   # Establishes a new #uri with the specified _fragment_.

--- a/spec/unit/htty/request_follow_spec.rb
+++ b/spec/unit/htty/request_follow_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 require File.expand_path("#{File.dirname __FILE__}/../../../lib/htty/request")
 require File.expand_path("#{File.dirname __FILE__}/../../../lib/htty/response")
 
+
 describe HTTY::Request do
   let(:request_address) {'http://example.com/a?b=c#d'}
   let(:request) {HTTY::Request.new request_address}
 
-  describe 'when #follow a response' do
+  describe '#follow a response' do
     let(:response) do
       HTTY::Response.new({:headers => {'Location' => response_location}})
     end
@@ -51,6 +52,14 @@ describe HTTY::Request do
         expected_uri.query = nil
         expected_uri.fragment = nil
         request.follow(response).uri.should == expected_uri
+      end
+
+      context 'when invoked more than once' do
+        let(:after_follow) {request.follow(response)}
+
+        it 'should return always the same request' do
+          after_follow.uri.should == after_follow.follow(response).uri
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #99

It's a little bit different from what we said, but I guess it makes more sense to follow a response than to follow a request and so the _follow state_ is kept inside the response
