### PR TITLE
Renamed option --debug to --show-backtrace

### DIFF
--- a/lib/htty/cli.rb
+++ b/lib/htty/cli.rb
@@ -58,7 +58,7 @@ class HTTY::CLI
             next
           end
 
-          if ARGV.include?('--debug')
+          if ARGV.include?('--show-backtrace')
             command.perform
           else
             rescuing_from Exception do


### PR DESCRIPTION
I thought that `--show-backtrace` it would be better because `--trace` or `--backtrace` it sounds like you are going to _trace_ something and not, in case of an exception, show the related backtrace, but I'm not a native speaker, if you don't like it I can change it back to `--backtrace`
