### PR TITLE
Preserve prompt on backspace

### DIFF
--- a/lib/htty/cli.rb
+++ b/lib/htty/cli.rb
@@ -34,9 +34,14 @@ class HTTY::CLI
     say_goodbye
   end
 
-  # This is something like should belong to Display
-  def visualize_prompt(message = '')
-    print prompt(@session.requests.last) + message
+  # This is something that should belong to Display
+  def line(command = '')
+     puts formatted_prompt + command
+  end
+
+  # This is something that should belong to Display
+  def formatted_prompt
+    formatted_prompt_for(@session.requests.last)
   end
 
 private

--- a/lib/htty/cli/display.rb
+++ b/lib/htty/cli/display.rb
@@ -82,7 +82,7 @@ module HTTY::CLI::Display
     end
   end
 
-  def prompt(request)
+  def formatted_prompt_for(request)
     format_request_uri(request.uri) + normal('> ')
   end
 

--- a/lib/htty/cli/input_device.rb
+++ b/lib/htty/cli/input_device.rb
@@ -19,7 +19,7 @@ module HTTY::CLI::InputDevice
         command_line.chomp!
         command_line.strip!
         next if command_line.empty?
-        @display.visualize_prompt(command_line + "\n")
+        @display.line(command_line)
         yield command_line
       end
     end
@@ -36,8 +36,7 @@ module HTTY::CLI::InputDevice
         begin
           command_line = ''
           while command_line.empty? do
-            @display.visualize_prompt
-            if (command_line = Readline.readline('', true)).nil?
+            if (command_line = Readline.readline(@display.formatted_prompt, true)).nil?
               raise Interrupt
             end
             if whitespace?(command_line) || repeat?(command_line)


### PR DESCRIPTION
The entire prompt must be passed to Readline otherwise Readline
doesn't know the length of the prompt and so when you delete something
on the command line the entire prompt it's deleted (also the history
gets corrupted somehow). This was not a behavioural bug, all worked ok
but aesthetically was quite annoying
