### PR TITLE
Update docs badge in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@
 [![Gemnasium build status]           ](http://gemnasium.com/htty/htty               "Gemnasium report")
 [![Code Climate code quality status] ](http://codeclimate.com/github/htty/htty      "Code Climate report")
 [![Code Climate test coverage status]](http://codeclimate.com/github/htty/htty      "Code Climate report")
-[![Inline build status]              ](http://inch-pages.github.io/github/htty/htty "Inline report")
+[![Inline build status]              ](http://inch-ci.org/github/htty/htty "Inline report")
 [![RubyGems release]                 ](http://rubygems.org/gems/htty                "RubyGems release")
 
 See what’s changed lately by reading the [project history](http://github.com/htty/htty/blob/master/History.markdown).
@@ -222,5 +222,5 @@ Released under the [MIT License](http://github.com/htty/htty/blob/master/License
 [Gemnasium build status]:            https://gemnasium.com/htty/htty.png
 [Code Climate code quality status]:  https://codeclimate.com/github/htty/htty.png
 [Code Climate test coverage status]: https://codeclimate.com/github/htty/htty/coverage.png
-[Inline build status]:               http://inch-pages.github.io/github/htty/htty.png
+[Inline build status]:               http://inch-ci.org/github/htty/htty.png
 [RubyGems release]:                  https://badge.fury.io/rb/htty.png


### PR DESCRIPTION
Hi there,

this patch updates the URL of the docs badge in your README. Inch's badges will be served from it's own CI service http://inch-ci.org in the future and I will slowly retire the old [Inch Pages project](http://inch-pages.github.io/). 

With the new service, people can [add projects straight from the homepage](http://inch-ci.org/) and also [configure a webhook to rebuild](http://inch-ci.org/howto/webhook) their badges auto-magically :star2:

I am so happy that Inch and Inch Pages were so well received in the community and that I am now able to keep [my promise](http://trivelop.de/2014/02/24/visibility-of-documentation/) to deliver a real, [open source](https://github.com/inch-ci) web service for the badges.

P.S. I have not written an announcement or anything for this, yet. **But**: Everybody who reads this is invited to add their projects to the site. Please help me find the last bugs, so I can start writing the "Introducing Inch CI" blog post :wink:
