### PR TITLE
Don't URL-encode slashes in 'cd' command

### DIFF
--- a/lib/htty/cli/commands/path_set.rb
+++ b/lib/htty/cli/commands/path_set.rb
@@ -40,7 +40,9 @@ class HTTY::CLI::Commands::PathSet < HTTY::CLI::Command
   def perform
     add_request_if_new do |request|
       self.class.notify_if_cookies_cleared request do
-        request.path_set(*escape_or_warn_of_escape_sequences(arguments))
+        request.path_set *(arguments.map do |argument|
+          escape_or_warn_of_escape_sequences(argument.split('/')).join('/')
+        end)
       end
     end
   end


### PR DESCRIPTION
Solution for #123. First we split  `cd` command arguments, then URL-encode if needed and finally join back.