### PR TITLE
Show correct request indexes when history contains requests without response

### DIFF
--- a/lib/htty/cli/commands/history.rb
+++ b/lib/htty/cli/commands/history.rb
@@ -34,10 +34,12 @@ class HTTY::CLI::Commands::History < HTTY::CLI::Command
   def perform
     requests = session.requests
     number_width = Math.log10(requests.length).to_i + 1
-    requests.each_with_index do |request, index|
+    index = 1
+    requests.each do |request|
       next unless request.response
 
-      number = (index + 1).to_s.rjust(number_width)
+      number = index.to_s.rjust(number_width)
+      index += 1
       print "#{strong number} "
       show_request request
 

--- a/lib/htty/cli/commands/history_verbose.rb
+++ b/lib/htty/cli/commands/history_verbose.rb
@@ -34,13 +34,17 @@ class HTTY::CLI::Commands::HistoryVerbose < HTTY::CLI::Command
     requests = session.requests
     number_width = Math.log10(requests.length).to_i + 1
     displayed_one = false
-    requests.each_with_index do |request, index|
+
+    index = 1
+
+    requests.each do |request|
       next unless request.response
 
       puts(strong('-' * 80)) if displayed_one
       displayed_one = true
 
-      number = (index + 1).to_s.rjust(number_width)
+      number = index.to_s.rjust(number_width)
+      index += 1
       print "#{strong number} "
       show_request request
 

--- a/lib/htty/cli/commands/reuse.rb
+++ b/lib/htty/cli/commands/reuse.rb
@@ -61,7 +61,7 @@ class HTTY::CLI::Commands::Reuse < HTTY::CLI::Command
     end
 
     add_request_if_new do
-      requests[index - 1].send :dup_without_response
+      requests_with_responses[index - 1].send :dup_without_response
     end
 
     puts notice("Using a copy of request ##{index}")


### PR DESCRIPTION
```
*** Welcome to  htty , the HTTP TTY. Heck To The Yeah!
http://localhost:3000/> g
*** Type cookies-u[se] to use cookies offered in the response
 200  OK -- 13 headers* -- 3728-character body
http://localhost:3000/> reuse 1
*** Using a copy of request #1
http://localhost:3000/> reuse 1
*** Using a copy of request #1
http://localhost:3000/> cd x
http://localhost:3000/x> g
*** Type fol[low] to follow the 'Location' header received in the response
 301  Moved Permanently -- 9 headers -- 88-character body
http://localhost:3000/x> history
1  GET  http://localhost:3000/ -- 1 header -- empty body
   200  OK -- 13 headers* -- 3728-character body
3  GET  http://localhost:3000/x -- 1 header -- empty body
   301  Moved Permanently -- 9 headers -- 88-character body
http://localhost:3000/x> reuse 3
*** Index must be between 1 and 2
```