### PR TITLE
Don't accumulate requests without response in session

### DIFF
--- a/lib/htty/cli/commands/reuse.rb
+++ b/lib/htty/cli/commands/reuse.rb
@@ -60,8 +60,10 @@ class HTTY::CLI::Commands::Reuse < HTTY::CLI::Command
       end
     end
 
-    add_request_if_new do
-      requests[index - 1].send :dup_without_response
+    add_request_if_new do |request|
+      session.requests.pop if request.response.nil?
+
+      requests[index - 1].send(:dup_without_response)
     end
 
     puts notice("Using a copy of request ##{index}")

--- a/spec/integration/htty/cli/commands/reuse_spec.rb
+++ b/spec/integration/htty/cli/commands/reuse_spec.rb
@@ -1,0 +1,29 @@
+require 'htty/cli/commands/reuse'
+
+RSpec.describe HTTY::CLI::Commands::Reuse do
+
+  let(:session) { HTTY::Session.new "http://google.com" }
+
+  def instance(*arguments)
+    described_class.new session: session, arguments: arguments
+  end
+
+  describe "#perform" do
+
+    let(:request) { HTTY::Request.new("http://facebook.com") }
+
+    before do
+      session.requests << request
+      session.requests.each { |request| allow(request).to receive(:response).and_return(true) }
+    end
+
+    it "shouldnt accumulate requests without response in session" do
+      instance(1).perform
+      instance(2).perform
+
+      expect(session.requests.count).to eq(3)
+      expect(session.requests.last.uri).to eq(request.uri)
+    end
+  end
+
+end


### PR DESCRIPTION
This is a solution for a second part of #142 problem. Multiple ``reuse`` command invocation was leading to accumulation of requests without response and as result we had problems with history.