### PR TITLE
Report response times #140

### DIFF
--- a/lib/htty/cli/display.rb
+++ b/lib/htty/cli/display.rb
@@ -153,11 +153,12 @@ module HTTY::CLI::Display
     end
     print ' '
     cookies_asterisk = response.cookies.empty? ? '' : strong('*')
-    body_length = response.body.to_s.length
-    body_size   = body_length.zero? ? 'empty' : "#{body_length}-character"
+    body_length      = response.body.to_s.length
+    body_size        = body_length.zero? ? 'empty' : "#{body_length}-character"
+    response_time    = (response.time * 1000).round(2)
     puts([description,
           pluralize('header', response.headers.length) + cookies_asterisk,
-          "#{body_size} body"].join(' -- '))
+          "#{body_size} body", "#{response_time} ms"].join(' -- '))
   end
 
   def strong(string)

--- a/lib/htty/requests_util.rb
+++ b/lib/htty/requests_util.rb
@@ -2,6 +2,7 @@ require 'htty'
 require 'net/http'
 require 'net/https'
 require 'uri'
+require 'benchmark'
 
 # Provides support for making HTTP(S) requests.
 module HTTY::RequestsUtil
@@ -89,7 +90,9 @@ private
     end
 
     http.start do |host|
-      http_response = yield(host)
+      http_response = nil
+      response_time = Benchmark.realtime { http_response = yield(host) }
+
       headers = []
       http_response.canonical_each do |*h|
         headers << h
@@ -97,7 +100,8 @@ private
       request.send :response=,
                    HTTY::Response.new(status:  http_response_to_status(http_response),
                                       headers: headers,
-                                      body:    http_response.body)
+                                      body:    http_response.body,
+                                      time:    response_time)
     end
     request
   end

--- a/lib/htty/response.rb
+++ b/lib/htty/response.rb
@@ -9,6 +9,8 @@ class HTTY::Response < HTTY::Payload
   # Returns the HTTP status associated with the response.
   attr_reader :status
 
+  attr_reader :time
+
   # Initializes a new HTTY::Response with attribute values specified in the
   # _attributes_ hash.
   #
@@ -20,6 +22,7 @@ class HTTY::Response < HTTY::Payload
   def initialize(attributes={})
     super attributes
     @status = attributes[:status]
+    @time   = attributes[:time]
     @already_followed = false
   end
 


### PR DESCRIPTION
Shows response time right after request and in history. Example:
```
http://ip.jsontest.com/> get
 200  OK -- 6 headers -- 23-character body -- 197.58 ms
```