### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2-alpine
+
+RUN \
+  gem install htty
+
+ENTRYPOINT [ "htty" ]


### PR DESCRIPTION
Adds Dockerfile to build Docker image, using community maintained official [Ruby](https://hub.docker.com/r/_/ruby/) 2.x latest on Alpine Linux (a minimal, tiny distro) as a base image. You can find an automated build here: https://hub.docker.com/r/pataquets/htty/

How to test:

```
$ docker run --rm -it pataquets/htty
```

It would be desirable to create an _official_ image at Docker Hub. You can even set up an automated build to trigger on each commit.
The steps would be:
- The project owner signs up.
- (If multiple persons in project/packging team) Create an organization 'htty'.
- Set up an 'automated build', linked to the Github repository.
- Profit!
  Thus the Docker image name will be `htty/htty`.
